### PR TITLE
Add playback error handling in SongSwiper component

### DIFF
--- a/components/SongSwiper.tsx
+++ b/components/SongSwiper.tsx
@@ -602,7 +602,7 @@ const SongSwiper: React.FC<SongSwiperProps> = ({
           ]}
         >
           <Text style={[styles.rankLabel, { color: textColor }]}>
-            What is your ranking? {currentRank > 0 ? `${currentRank}` : ''}
+            What is your ranking?
           </Text>
           <View style={styles.rankButtons}>
             {[1, 2, 3, 4, 5].map((v) => (


### PR DESCRIPTION
Handles cases when song does not have a previewURI or the one provided fails to load. Provides better error handling for such cases. Changes the play button to a error/warning button when song fails to load.
![rankingpage-playback-error-handling](https://github.com/user-attachments/assets/5b34df9a-aaa1-46d4-a1f8-4094578c0cb1)
